### PR TITLE
Adding more functionality

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,18 +36,3 @@ jobs:
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
-  tickeryzer:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
-
-    - name: Install Tickeryzer
-      run: go get -u github.com/orijtech/tickeryzer/cmd/tickeryzer
-
-    - name: Run Tickeryzer
-      run: tickeryzer ./...

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ func TestFunc(t *testing.T) {
 		}
 
 		// Start HTTP Listener
-		err = http.ListenAndServeTLS("localhost:443", cert, key, someHandler)
+		err = http.ListenAndServeTLS("localhost:443", "/tmp/cert", "/tmp/key", someHandler)
 		if err != nil {
 			// do something
 		}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ func TestFunc(t *testing.T) {
 	}
 
 	// Make an HTTPS request
-	r, _ := client.Get("https://myserver.internal.net:9443")
+	r, _ := client.Get("https://localhost")
 }
 ```
 

--- a/testcerts.go
+++ b/testcerts.go
@@ -1,23 +1,64 @@
 /*
-Package testcerts provides a set of functions for generating and saving x509 test certificates to file.
+Package testcerts provides an easy-to-use suite of functions for generating x509 test certificates.
 
-This package can be used in testing and development environments where a set of trusted certificates are needed.
-The main function, GenerateCertsToTempFile, generates an x509 certificate and key and writes them to a randomly
-named file in a specified or temporary directory.
+Stop saving test certificates in your code repos. Start generating them in your tests.
 
-For example, to generate and save a certificate and key to a temporary directory:
-
-	func TestSomething(t *testing.T) {
-		certFile, keyFile, err := testcerts.GenerateCertsToTempFile("/tmp/")
+	func TestFunc(t *testing.T) {
+		// Create and write self-signed Certificate and Key to temporary files
+		cert, key, err := testcerts.GenerateToTempFile("/tmp/")
 		if err != nil {
-			// do stuff
+			// do something
 		}
+		defer os.Remove(key)
+		defer os.Remove(cert)
 
-		_ = something.Run(certFile, keyFile)
-		// do more testing
+		// Start HTTP Listener with test certificates
+		err = http.ListenAndServeTLS("127.0.0.1:443", cert, key, someHandler)
+		if err != nil {
+			// do something
+		}
 	}
 
-This will create a temporary certificate and key and print the paths to where the files were written.
+For more complex tests, you can also use this package to create a Certificate Authority and a key pair signed by that Certificate Authority for any test domain you want.
+
+	func TestFunc(t *testing.T) {
+		// Generate Certificate Authority
+		ca := testcerts.NewCA()
+
+		go func() {
+			// Create a signed Certificate and Key for "localhost"
+			certs, err := ca.NewKeyPair("localhost")
+			if err != nil {
+				// do something
+			}
+
+			// Write certificates to a file
+			err = certs.ToFile("/tmp/cert", "/tmp/key")
+			if err {
+				// do something
+			}
+
+			// Start HTTP Listener
+			err = http.ListenAndServeTLS("localhost:443", cert, key, someHandler)
+			if err != nil {
+				// do something
+			}
+		}()
+
+		// Create a client with the self-signed CA
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: ca.CertPool(),
+				},
+			},
+		}
+
+		// Make an HTTPS request
+		r, _ := client.Get("https://localhost:443")
+	}
+
+Simplify your testing, and don't hassle with certificates anymore.
 */
 package testcerts
 
@@ -33,6 +74,196 @@ import (
 	"time"
 )
 
+// CertificateAuthority represents an x509 certificate authority.
+type CertificateAuthority struct {
+	cert       *x509.Certificate
+	certPool   *x509.CertPool
+	publicKey  *pem.Block
+	privateKey *pem.Block
+}
+
+// KeyPair represents a pair of x509 certificate and private key.
+type KeyPair struct {
+	cert       *x509.Certificate
+	publicKey  *pem.Block
+	privateKey *pem.Block
+}
+
+// NewCA creates a new CertificateAuthority.
+func NewCA() *CertificateAuthority {
+	// Create a Certificate Authority Cert
+	ca := &CertificateAuthority{cert: &x509.Certificate{
+		Subject: pkix.Name{
+			Organization: []string{"Never Use this Certificate in Production Inc."},
+		},
+		SerialNumber:          big.NewInt(42),
+		NotAfter:              time.Now().Add(2 * time.Hour),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}}
+
+	var err error
+
+	// Generate KeyPair
+	ca.publicKey, ca.privateKey, err = genKeyPair(ca.cert, ca.cert)
+	if err != nil {
+		// Should never error, but just incase
+		return ca
+	}
+
+	// Crete CertPool
+	ca.certPool = x509.NewCertPool()
+	result := ca.certPool.AppendCertsFromPEM(ca.PublicKey())
+	if !result {
+		// if error set an empty pool
+		ca.certPool = x509.NewCertPool()
+	}
+
+	return ca
+}
+
+// NewKeyPair generates a new KeyPair signed by the CertificateAuthority for the given domains.
+// The domains are used to populate the Subject Alternative Name field of the certificate.
+// Returns an error if any of the given domains are invalid.
+func (ca *CertificateAuthority) NewKeyPair(domains ...string) (*KeyPair, error) {
+	// Create a Certificate
+	kp := &KeyPair{cert: &x509.Certificate{
+		Subject: pkix.Name{
+			Organization: []string{"Never Use this Certificate in Production Inc."},
+		},
+		DNSNames:              domains,
+		SerialNumber:          big.NewInt(42),
+		NotAfter:              time.Now().Add(2 * time.Hour),
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}}
+
+	var err error
+	kp.publicKey, kp.privateKey, err = genKeyPair(ca.cert, kp.cert)
+	if err != nil {
+		return kp, fmt.Errorf("could not generate keypair: %s", err)
+	}
+	return kp, nil
+}
+
+// CertPool returns a Certificate Pool of the CertificateAuthority Certificate
+func (ca *CertificateAuthority) CertPool() *x509.CertPool {
+	return ca.certPool
+}
+
+// PrivateKey returns the private key of the CertificateAuthority.
+func (ca *CertificateAuthority) PrivateKey() []byte {
+	return pem.EncodeToMemory(ca.privateKey)
+}
+
+// PublicKey returns the public key of the CertificateAuthority.
+func (ca *CertificateAuthority) PublicKey() []byte {
+	return pem.EncodeToMemory(ca.publicKey)
+}
+
+// ToFile saves the CertificateAuthority certificate and private key to the specified files.
+// Returns an error if any file operation fails.
+func (ca *CertificateAuthority) ToFile(certFile, keyFile string) error {
+	// Write Certificate
+	err := os.WriteFile(certFile, ca.PublicKey(), 0640)
+	if err != nil {
+		return fmt.Errorf("unable to create certificate file - %s", err)
+	}
+
+	// Write Key
+	err = os.WriteFile(keyFile, ca.PrivateKey(), 0640)
+	if err != nil {
+		return fmt.Errorf("unable to create certificate file - %s", err)
+	}
+
+	return nil
+}
+
+// ToTempFile saves the CertificateAuthority certificate and private key to temporary files.
+// The temporary files are created in the specified directory and have random names.
+func (ca *CertificateAuthority) ToTempFile(dir string) (*os.File, *os.File, error) {
+	cfh, err := os.CreateTemp(dir, "*.cert")
+	if err != nil {
+		return &os.File{}, &os.File{}, fmt.Errorf("could not create temporary file - %s", err)
+	}
+	defer cfh.Close()
+	_, err = cfh.Write(ca.PublicKey())
+	if err != nil {
+		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
+	}
+
+	// Write to Key File
+	kfh, err := os.CreateTemp(dir, "*.key")
+	if err != nil {
+		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
+	}
+	defer kfh.Close()
+	_, err = kfh.Write(ca.PrivateKey())
+	if err != nil {
+		return cfh, kfh, fmt.Errorf("unable to create certificate file - %s", err)
+	}
+
+	return cfh, kfh, nil
+}
+
+// PrivateKey returns the private key of the KeyPair.
+func (kp *KeyPair) PrivateKey() []byte {
+	return pem.EncodeToMemory(kp.privateKey)
+}
+
+// PublicKey returns the public key of the KeyPair.
+func (kp *KeyPair) PublicKey() []byte {
+	return pem.EncodeToMemory(kp.publicKey)
+}
+
+// ToFile saves the KeyPair certificate and private key to the specified files.
+// Returns an error if any file operation fails.
+func (kp *KeyPair) ToFile(certFile, keyFile string) error {
+	// Write Certificate
+	err := os.WriteFile(certFile, kp.PublicKey(), 0640)
+	if err != nil {
+		return fmt.Errorf("unable to create certificate file - %s", err)
+	}
+
+	// Write Key
+	err = os.WriteFile(keyFile, kp.PrivateKey(), 0640)
+	if err != nil {
+		return fmt.Errorf("unable to create key file - %s", err)
+	}
+
+	return nil
+}
+
+// ToTempFile saves the KeyPair certificate and private key to temporary files.
+// The temporary files are created in the specified directory and have random names.
+func (kp *KeyPair) ToTempFile(dir string) (*os.File, *os.File, error) {
+	cfh, err := os.CreateTemp(dir, "*.cert")
+	if err != nil {
+		return &os.File{}, &os.File{}, fmt.Errorf("could not create temporary file - %s", err)
+	}
+	defer cfh.Close()
+	_, err = cfh.Write(kp.PublicKey())
+	if err != nil {
+		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
+	}
+
+	// Write to Key File
+	kfh, err := os.CreateTemp(dir, "*.key")
+	if err != nil {
+		return cfh, &os.File{}, fmt.Errorf("unable to create key file - %s", err)
+	}
+	defer kfh.Close()
+	_, err = kfh.Write(kp.PrivateKey())
+	if err != nil {
+		return cfh, kfh, fmt.Errorf("unable to create key file - %s", err)
+	}
+
+	return cfh, kfh, nil
+}
+
 // GenerateCerts generates an x509 certificate and key.
 // It returns the certificate and key as byte slices, and any error that occurred.
 //
@@ -40,13 +271,20 @@ import (
 //	if err != nil {
 //		// handle error
 //	}
-func GenerateCerts() ([]byte, []byte, error) {
-	// Create certs and return as []byte
-	c, k, err := genCerts()
+func GenerateCerts(domains ...string) ([]byte, []byte, error) {
+	ca := NewCA()
+
+	// Returning CA for backwards compatibility
+	if len(domains) == 0 {
+		return ca.PublicKey(), ca.PrivateKey(), nil
+	}
+
+	// If domains exist return a regular cert
+	kp, err := ca.NewKeyPair(domains...)
 	if err != nil {
 		return nil, nil, err
 	}
-	return pem.EncodeToMemory(c), pem.EncodeToMemory(k), nil
+	return kp.PublicKey(), kp.PrivateKey(), nil
 }
 
 // GenerateCertsToFile creates an x509 certificate and key and writes it to the specified file paths.
@@ -58,35 +296,8 @@ func GenerateCerts() ([]byte, []byte, error) {
 //
 // If the specified file paths already exist, it will overwrite the existing files.
 func GenerateCertsToFile(certFile, keyFile string) error {
-	// Create Certs
-	c, k, err := GenerateCerts()
-	if err != nil {
-		return err
-	}
-
-	// Write Certificate
-	cfh, err := os.Create(certFile)
-	if err != nil {
-		return fmt.Errorf("unable to create certificate file - %s", err)
-	}
-	defer cfh.Close()
-	_, err = cfh.Write(c)
-	if err != nil {
-		return fmt.Errorf("unable to create certificate file - %s", err)
-	}
-
-	// Write Key
-	kfh, err := os.Create(keyFile)
-	if err != nil {
-		return fmt.Errorf("unable to create certificate file - %s", err)
-	}
-	defer kfh.Close()
-	_, err = kfh.Write(k)
-	if err != nil {
-		return fmt.Errorf("unable to create certificate file - %s", err)
-	}
-
-	return nil
+	// Create Certs using CA for backwards compatibility
+	return NewCA().ToFile(certFile, keyFile)
 }
 
 // GenerateCertsToTempFile will create a temporary x509 certificate and key in a randomly generated file using the
@@ -98,51 +309,17 @@ func GenerateCertsToFile(certFile, keyFile string) error {
 //		// handle error
 //	}
 func GenerateCertsToTempFile(dir string) (string, string, error) {
-	// Create Certs
-	c, k, err := GenerateCerts()
+	// Create Certs using CA for backwards compatibility
+	cert, key, err := NewCA().ToTempFile(dir)
 	if err != nil {
 		return "", "", err
 	}
 
-	cfh, err := os.CreateTemp(dir, "*.cert")
-	if err != nil {
-		return "", "", fmt.Errorf("could not create temporary file - %s", err)
-	}
-	defer cfh.Close()
-	_, err = cfh.Write(c)
-	if err != nil {
-		return cfh.Name(), "", fmt.Errorf("unable to create certificate file - %s", err)
-	}
-
-	// Write to Key File
-	kfh, err := os.CreateTemp(dir, "*.key")
-	if err != nil {
-		return cfh.Name(), "", fmt.Errorf("unable to create certificate file - %s", err)
-	}
-	defer kfh.Close()
-	_, err = kfh.Write(k)
-	if err != nil {
-		return cfh.Name(), kfh.Name(), fmt.Errorf("unable to create certificate file - %s", err)
-	}
-
-	return cfh.Name(), kfh.Name(), nil
+	return cert.Name(), key.Name(), nil
 }
 
-// genCerts will perform the task of creating a temporary Certificate and Key.
-func genCerts() (*pem.Block, *pem.Block, error) {
-	// Create a Certificate Authority Cert
-	ca := &x509.Certificate{
-		Subject: pkix.Name{
-			Organization: []string{"Never Use this Certificate in Production Inc."},
-		},
-		SerialNumber:          big.NewInt(42),
-		NotAfter:              time.Now().Add(2 * time.Hour),
-		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-	}
-
+// genKeyPair will generate a key and certificate from the provided Certificate and CA.
+func genKeyPair(ca *x509.Certificate, cert *x509.Certificate) (*pem.Block, *pem.Block, error) {
 	// Create a Private Key
 	key, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
@@ -150,14 +327,13 @@ func genCerts() (*pem.Block, *pem.Block, error) {
 	}
 
 	// Use CA Cert to sign a CSR and create a Public Cert
-	csr := &key.PublicKey
-	cert, err := x509.CreateCertificate(rand.Reader, ca, ca, csr, key)
+	certificate, err := x509.CreateCertificate(rand.Reader, cert, ca, &key.PublicKey, key)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not generate certificate - %s", err)
 	}
 
 	// Convert keys into pem.Block
-	c := &pem.Block{Type: "CERTIFICATE", Bytes: cert}
+	c := &pem.Block{Type: "CERTIFICATE", Bytes: certificate}
 	k := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
 	return c, k, nil
 }

--- a/testcerts.go
+++ b/testcerts.go
@@ -55,7 +55,7 @@ For more complex tests, you can also use this package to create a Certificate Au
 		}
 
 		// Make an HTTPS request
-		r, _ := client.Get("https://localhost:443")
+		r, _ := client.Get("https://localhost")
 	}
 
 Simplify your testing, and don't hassle with certificates anymore.

--- a/testcerts_test.go
+++ b/testcerts_test.go
@@ -1,10 +1,205 @@
 package testcerts
 
 import (
+	"crypto/x509"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestCertsUsage(t *testing.T) {
+	// Generate Happy Path
+
+	// Generate No Domains
+
+	// Generate CA
+	ca := NewCA()
+	if len(ca.PrivateKey()) == 0 || len(ca.PublicKey()) == 0 {
+		t.Errorf("Unexpected key length from public/private key")
+	}
+
+	t.Run("Verify CertPool", func(t *testing.T) {
+		cp := x509.NewCertPool()
+		if cp.AppendCertsFromPEM(ca.PublicKey()) {
+			if cp.Equal(ca.CertPool()) {
+				return
+			}
+		}
+		t.Errorf("certpool is not valid")
+	})
+
+	t.Run("Write to File", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "")
+		if err != nil {
+			t.Errorf("Error creating temporary directory: %s", err)
+			return
+		}
+		defer os.RemoveAll(tempDir)
+
+		certPath := filepath.Join(tempDir, "cert")
+		keyPath := filepath.Join(tempDir, "key")
+
+		err = ca.ToFile(certPath, keyPath)
+		if err != nil {
+			t.Errorf("Error while generating certificates to files - %s", err)
+		}
+
+		// Check if Cert file exists
+		_, err = os.Stat(certPath)
+		if err != nil {
+			t.Errorf("Error while generating certificates to files file error - %s", err)
+		}
+
+		// Check if Key file exists
+		_, err = os.Stat(keyPath)
+		if err != nil {
+			t.Errorf("Error while generating certificates to files file error - %s", err)
+		}
+	})
+
+	t.Run("Write to Invalid File", func(t *testing.T) {
+		certPath := "/notValid/path/cert"
+		keyPath := "/notValid/path/key"
+
+		err := ca.ToFile(certPath, keyPath)
+		if err == nil {
+			t.Errorf("Unexpected success generating certificates to files")
+		}
+
+		// Check if Cert file exists
+		_, err = os.Stat(certPath)
+		if !os.IsNotExist(err) {
+			t.Errorf("Unexpected success while generating certificates to files")
+		}
+
+		// Check if Key file exists
+		_, err = os.Stat(keyPath)
+		if !os.IsNotExist(err) {
+			t.Errorf("Unexpected success while generating certificates to files")
+		}
+	})
+
+	t.Run("Write to TempFile", func(t *testing.T) {
+		cert, key, err := ca.ToTempFile("")
+		if err != nil {
+			t.Errorf("Error generating tempfile - %s", err)
+		}
+
+		_, err = os.Stat(cert.Name())
+		if err != nil {
+			t.Errorf("File does not exist - %s", cert.Name())
+		}
+		defer os.Remove(cert.Name())
+
+		_, err = os.Stat(key.Name())
+		if err != nil {
+			t.Errorf("File does not exist - %s", key.Name())
+		}
+		defer os.Remove(key.Name())
+	})
+
+	t.Run("Write to Invalid TempFile", func(t *testing.T) {
+		_, _, err := ca.ToTempFile("/notValidPath/")
+		if err == nil {
+			t.Errorf("Unexpected success with invalid tempfile directory")
+		}
+	})
+
+	for _, domains := range [][]string{{"localhost", "127.0.0.1", "example.com"}, {}} {
+		t.Run(fmt.Sprintf("Generate KeyPair with %d Domains", len(domains)), func(t *testing.T) {
+			kp, err := ca.NewKeyPair(domains...)
+			if err != nil {
+				t.Errorf("NewKeyPair() returned error when generating with domains: %s", err)
+			}
+
+			t.Run("Validate Key Length", func(t *testing.T) {
+				if len(kp.PrivateKey()) == 0 || len(kp.PublicKey()) == 0 {
+					t.Errorf("Unexpected key length from public/private key")
+				}
+			})
+
+			t.Run("Write to File", func(t *testing.T) {
+				tempDir, err := os.MkdirTemp("", "")
+				if err != nil {
+					t.Errorf("Error creating temporary directory: %s", err)
+					return
+				}
+				defer os.RemoveAll(tempDir)
+
+				certPath := filepath.Join(tempDir, "cert")
+				keyPath := filepath.Join(tempDir, "key")
+
+				err = kp.ToFile(certPath, keyPath)
+				if err != nil {
+					t.Errorf("Error while generating certificates to files - %s", err)
+				}
+
+				// Check if Cert file exists
+				_, err = os.Stat(certPath)
+				if err != nil {
+					t.Errorf("Error while generating certificates to files file error - %s", err)
+				}
+
+				// Check if Key file exists
+				_, err = os.Stat(keyPath)
+				if err != nil {
+					t.Errorf("Error while generating certificates to files file error - %s", err)
+				}
+			})
+
+			t.Run("Write to Invalid File", func(t *testing.T) {
+				certPath := "/notValid/path/cert"
+				keyPath := "/notValid/path/key"
+
+				err := kp.ToFile(certPath, keyPath)
+				if err == nil {
+					t.Errorf("Unexpected success generating certificates to files")
+				}
+
+				// Check if Cert file exists
+				_, err = os.Stat(certPath)
+				if !os.IsNotExist(err) {
+					t.Errorf("Unexpected success while generating certificates to files")
+				}
+
+				// Check if Key file exists
+				_, err = os.Stat(keyPath)
+				if !os.IsNotExist(err) {
+					t.Errorf("Unexpected success while generating certificates to files")
+				}
+			})
+
+			t.Run("Write to TempFile", func(t *testing.T) {
+				cert, key, err := kp.ToTempFile("")
+				if err != nil {
+					t.Errorf("Error generating tempfile - %s", err)
+				}
+
+				_, err = os.Stat(cert.Name())
+				if err != nil {
+					t.Errorf("File does not exist - %s", cert.Name())
+				}
+				defer os.Remove(cert.Name())
+
+				_, err = os.Stat(key.Name())
+				if err != nil {
+					t.Errorf("File does not exist - %s", key.Name())
+				}
+				defer os.Remove(key.Name())
+			})
+
+			t.Run("Write to Invalid TempFile", func(t *testing.T) {
+				_, _, err := kp.ToTempFile("/notValidPath/")
+				if err == nil {
+					t.Errorf("Unexpected success with invalid tempfile directory")
+				}
+			})
+
+		})
+	}
+
+}
 
 func TestGeneratingCerts(t *testing.T) {
 	_, _, err := GenerateCerts()


### PR DESCRIPTION
This pull request adds quite a bit more functionality to testcerts.

1. Adds functions for creating a Certificate Authority
2. Adds functions for creating a KeyPair using custom domains
3. Updates existing functions to allow for custom domains without breaking contracts
4. Keeps existing function behavior the same in case anyone was using certs for certificate authority purposes
5. Updated docs
6. Tests generated by your friend ChatGPT....