### PR TITLE
fix: use ca private key to sign derived certs

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.19
+        go-version: ^1.20
       id: go
 
     - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/madflojo/testcerts
 
-go 1.19
+go 1.20

--- a/testcerts.go
+++ b/testcerts.go
@@ -154,7 +154,7 @@ func (ca *CertificateAuthority) NewKeyPair(domains ...string) (*KeyPair, error) 
 	var privateKey *ecdsa.PrivateKey
 	kp.publicKey, privateKey, err = genKeyPair(ca.cert, ca.privateKeyEcdsa, kp.cert)
 	if err != nil {
-		return kp, fmt.Errorf("could not generate keypair: %s", err)
+		return kp, fmt.Errorf("could not generate keypair: %w", err)
 	}
 	kp.privateKey, err = keyToPemBlock(privateKey)
 	if err != nil {
@@ -184,13 +184,13 @@ func (ca *CertificateAuthority) ToFile(certFile, keyFile string) error {
 	// Write Certificate
 	err := os.WriteFile(certFile, ca.PublicKey(), 0640)
 	if err != nil {
-		return fmt.Errorf("unable to create certificate file - %s", err)
+		return fmt.Errorf("unable to create certificate file - %w", err)
 	}
 
 	// Write Key
 	err = os.WriteFile(keyFile, ca.PrivateKey(), 0640)
 	if err != nil {
-		return fmt.Errorf("unable to create certificate file - %s", err)
+		return fmt.Errorf("unable to create certificate file - %w", err)
 	}
 
 	return nil
@@ -202,7 +202,7 @@ func (ca *CertificateAuthority) ToTempFile(dir string) (cfh *os.File, kfh *os.Fi
 	// Write Certificate
 	cfh, err = os.CreateTemp(dir, "*.cert")
 	if err != nil {
-		return &os.File{}, &os.File{}, fmt.Errorf("could not create temporary file - %s", err)
+		return &os.File{}, &os.File{}, fmt.Errorf("could not create temporary file - %w", err)
 	}
 	defer func() {
 		if closeErr := cfh.Close(); closeErr != nil {
@@ -211,13 +211,13 @@ func (ca *CertificateAuthority) ToTempFile(dir string) (cfh *os.File, kfh *os.Fi
 	}()
 	_, err = cfh.Write(ca.PublicKey())
 	if err != nil {
-		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
+		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %w", err)
 	}
 
 	// Write Key
 	kfh, err = os.CreateTemp(dir, "*.key")
 	if err != nil {
-		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
+		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %w", err)
 	}
 	defer func() {
 		if closeErr := kfh.Close(); closeErr != nil {
@@ -226,7 +226,7 @@ func (ca *CertificateAuthority) ToTempFile(dir string) (cfh *os.File, kfh *os.Fi
 	}()
 	_, err = kfh.Write(ca.PrivateKey())
 	if err != nil {
-		return cfh, kfh, fmt.Errorf("unable to create certificate file - %s", err)
+		return cfh, kfh, fmt.Errorf("unable to create certificate file - %w", err)
 	}
 
 	return cfh, kfh, nil
@@ -248,13 +248,13 @@ func (kp *KeyPair) ToFile(certFile, keyFile string) error {
 	// Write Certificate
 	err := os.WriteFile(certFile, kp.PublicKey(), 0640)
 	if err != nil {
-		return fmt.Errorf("unable to create certificate file - %s", err)
+		return fmt.Errorf("unable to create certificate file - %w", err)
 	}
 
 	// Write Key
 	err = os.WriteFile(keyFile, kp.PrivateKey(), 0640)
 	if err != nil {
-		return fmt.Errorf("unable to create key file - %s", err)
+		return fmt.Errorf("unable to create key file - %w", err)
 	}
 
 	return nil
@@ -266,7 +266,7 @@ func (kp *KeyPair) ToTempFile(dir string) (cfh *os.File, kfh *os.File, err error
 	// Write Certificate
 	cfh, err = os.CreateTemp(dir, "*.cert")
 	if err != nil {
-		return &os.File{}, &os.File{}, fmt.Errorf("could not create temporary file - %s", err)
+		return &os.File{}, &os.File{}, fmt.Errorf("could not create temporary file - %w", err)
 	}
 	defer func() {
 		if closeErr := cfh.Close(); closeErr != nil {
@@ -275,13 +275,13 @@ func (kp *KeyPair) ToTempFile(dir string) (cfh *os.File, kfh *os.File, err error
 	}()
 	_, err = cfh.Write(kp.PublicKey())
 	if err != nil {
-		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
+		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %w", err)
 	}
 
 	// Write Key
 	kfh, err = os.CreateTemp(dir, "*.key")
 	if err != nil {
-		return cfh, &os.File{}, fmt.Errorf("unable to create key file - %s", err)
+		return cfh, &os.File{}, fmt.Errorf("unable to create key file - %w", err)
 	}
 	defer func() {
 		if closeErr := kfh.Close(); closeErr != nil {
@@ -290,7 +290,7 @@ func (kp *KeyPair) ToTempFile(dir string) (cfh *os.File, kfh *os.File, err error
 	}()
 	_, err = kfh.Write(kp.PrivateKey())
 	if err != nil {
-		return cfh, kfh, fmt.Errorf("unable to create key file - %s", err)
+		return cfh, kfh, fmt.Errorf("unable to create key file - %w", err)
 	}
 
 	return cfh, kfh, nil
@@ -355,13 +355,13 @@ func genSelfSignedKeyPair(cert *x509.Certificate) (*pem.Block, *ecdsa.PrivateKey
 	// Create a Private Key
 	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not generate rsa key - %s", err)
+		return nil, nil, fmt.Errorf("could not generate rsa key - %w", err)
 	}
 
 	// Use CA Cert to sign and create a Public Cert
 	signedCert, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not generate self-signed certificate - %s", err)
+		return nil, nil, fmt.Errorf("could not generate self-signed certificate - %w", err)
 	}
 	return certToPemBlock(signedCert), key, err
 }
@@ -371,12 +371,12 @@ func genKeyPair(ca *x509.Certificate, caKey *ecdsa.PrivateKey, cert *x509.Certif
 	// Create a Private Key
 	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not generate rsa key - %s", err)
+		return nil, nil, fmt.Errorf("could not generate rsa key - %w", err)
 	}
 
 	signedCert, err := x509.CreateCertificate(rand.Reader, cert, ca, &key.PublicKey, caKey)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not generate self-signed certificate - %s", err)
+		return nil, nil, fmt.Errorf("could not generate self-signed certificate - %w", err)
 	}
 	return certToPemBlock(signedCert), key, nil
 }
@@ -386,7 +386,7 @@ func keyToPemBlock(key *ecdsa.PrivateKey) (*pem.Block, error) {
 	// Convert key into pem.Block
 	kb, err := x509.MarshalPKCS8PrivateKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal private key - %s", err)
+		return nil, fmt.Errorf("could not marshal private key - %w", err)
 	}
 	k := &pem.Block{Type: "PRIVATE KEY", Bytes: kb}
 	return k, nil

--- a/testcerts.go
+++ b/testcerts.go
@@ -69,6 +69,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -197,24 +198,32 @@ func (ca *CertificateAuthority) ToFile(certFile, keyFile string) error {
 
 // ToTempFile saves the CertificateAuthority certificate and private key to temporary files.
 // The temporary files are created in the specified directory and have random names.
-func (ca *CertificateAuthority) ToTempFile(dir string) (*os.File, *os.File, error) {
+func (ca *CertificateAuthority) ToTempFile(dir string) (cfh *os.File, kfh *os.File, err error) {
 	// Write Certificate
-	cfh, err := os.CreateTemp(dir, "*.cert")
+	cfh, err = os.CreateTemp(dir, "*.cert")
 	if err != nil {
 		return &os.File{}, &os.File{}, fmt.Errorf("could not create temporary file - %s", err)
 	}
-	defer cfh.Close()
+	defer func() {
+		if closeErr := cfh.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
 	_, err = cfh.Write(ca.PublicKey())
 	if err != nil {
 		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
 	}
 
 	// Write Key
-	kfh, err := os.CreateTemp(dir, "*.key")
+	kfh, err = os.CreateTemp(dir, "*.key")
 	if err != nil {
 		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
 	}
-	defer kfh.Close()
+	defer func() {
+		if closeErr := kfh.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
 	_, err = kfh.Write(ca.PrivateKey())
 	if err != nil {
 		return cfh, kfh, fmt.Errorf("unable to create certificate file - %s", err)
@@ -253,24 +262,32 @@ func (kp *KeyPair) ToFile(certFile, keyFile string) error {
 
 // ToTempFile saves the KeyPair certificate and private key to temporary files.
 // The temporary files are created in the specified directory and have random names.
-func (kp *KeyPair) ToTempFile(dir string) (*os.File, *os.File, error) {
+func (kp *KeyPair) ToTempFile(dir string) (cfh *os.File, kfh *os.File, err error) {
 	// Write Certificate
-	cfh, err := os.CreateTemp(dir, "*.cert")
+	cfh, err = os.CreateTemp(dir, "*.cert")
 	if err != nil {
 		return &os.File{}, &os.File{}, fmt.Errorf("could not create temporary file - %s", err)
 	}
-	defer cfh.Close()
+	defer func() {
+		if closeErr := cfh.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
 	_, err = cfh.Write(kp.PublicKey())
 	if err != nil {
 		return cfh, &os.File{}, fmt.Errorf("unable to create certificate file - %s", err)
 	}
 
 	// Write Key
-	kfh, err := os.CreateTemp(dir, "*.key")
+	kfh, err = os.CreateTemp(dir, "*.key")
 	if err != nil {
 		return cfh, &os.File{}, fmt.Errorf("unable to create key file - %s", err)
 	}
-	defer kfh.Close()
+	defer func() {
+		if closeErr := kfh.Close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
 	_, err = kfh.Write(kp.PrivateKey())
 	if err != nil {
 		return cfh, kfh, fmt.Errorf("unable to create key file - %s", err)

--- a/testcerts_test.go
+++ b/testcerts_test.go
@@ -349,12 +349,14 @@ func testUsingCerts(t *testing.T, rootCAs func(ca *CertificateAuthority, certs *
 	certs, err := ca.NewKeyPair("localhost")
 	if err != nil {
 		t.Errorf("Error generating keypair - %s", err)
+		return
 	}
 
 	// Write certificates to a file
 	cert, key, err := certs.ToTempFile("")
 	if err != nil {
 		t.Errorf("Error writing certs to temp files - %s", err)
+		return
 	}
 
 	// Create HTTP Server

--- a/testcerts_test.go
+++ b/testcerts_test.go
@@ -377,7 +377,7 @@ func testUsingCerts(t *testing.T, rootCAs func(ca *CertificateAuthority, certs *
 	// Setup HTTP Client with Cert Pool
 	certpool := rootCAs(ca, certs)
 	if certpool == nil {
-		t.Error("Test configuration resulted in nil certpool returned from rootCAs func arg")
+		t.Error("Test configuration error: rootCAs arg function returned nil instead of a x509.CertPool")
 		return
 	}
 	client := &http.Client{

--- a/testcerts_test.go
+++ b/testcerts_test.go
@@ -375,10 +375,14 @@ func testUsingCerts(t *testing.T, rootCAs func(ca *CertificateAuthority, certs *
 	<-time.After(3 * time.Second)
 
 	// Setup HTTP Client with Cert Pool
+	certpool := rootCAs(ca, certs)
+	if certpool == nil {
+		t.Error("Test configuration resulted in nil certpool returned from rootCAs func arg")
+	}
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs: rootCAs(ca, certs),
+				RootCAs: certpool,
 			},
 		},
 	}

--- a/testcerts_test.go
+++ b/testcerts_test.go
@@ -378,6 +378,7 @@ func testUsingCerts(t *testing.T, rootCAs func(ca *CertificateAuthority, certs *
 	certpool := rootCAs(ca, certs)
 	if certpool == nil {
 		t.Error("Test configuration resulted in nil certpool returned from rootCAs func arg")
+		return
 	}
 	client := &http.Client{
 		Transport: &http.Transport{


### PR DESCRIPTION
Great project!

Tried it out for a pet project of mine, but could not get the `http.Client` to work using the certificate pool from `CertificateAuthority.CertPool`.

Reason is that the private key of the cert is used to sign it and not the private key of the CA, so one ends up always with a selfsigned cert and the certPool of the CA is not sufficient.

This PR fixes this (needed a bit of refactoring to pass a version of the CA privateKey to the signing methods without altering public functions). Also added a test to cover this aspect and some small improvements regarding error handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the certificate handling mechanism, improving the security and flexibility of the system. The update allows for the use of both self-signed certificates and those issued by a Certificate Authority (CA), catering to different security needs.
- Test: Expanded test coverage to include scenarios for both self-signed certificates and CA-issued certificates, ensuring robustness and reliability of the certificate handling feature.
  
Please note, these changes are under-the-hood improvements and won't directly affect the user interface. However, they significantly enhance the system's security and adaptability to different certificate types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->