### PR TITLE
Add ability to pass Serial Number and Common Name

### DIFF
--- a/kpconfig.go
+++ b/kpconfig.go
@@ -2,6 +2,7 @@ package testcerts
 
 import (
 	"errors"
+	"math/big"
 	"net"
 )
 
@@ -22,6 +23,12 @@ type KeyPairConfig struct {
 	// IPAddresses is a list of IP addresses to include in the certificate
 	// as Subject Alternative Names.
 	IPAddresses []string
+
+	// SerialNumber is the serial number to use for the certificate.
+	SerialNumber *big.Int
+
+	// CommonName is the Common Name to use for the certificate.
+	CommonName string
 }
 
 // Validate validates the KeyPairConfig ensuring that it is not empty and that

--- a/testcerts.go
+++ b/testcerts.go
@@ -62,7 +62,6 @@ Simplify your testing, and don't hassle with certificates anymore.
 package testcerts
 
 import (
-	"cmp"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -159,6 +158,12 @@ func (ca *CertificateAuthority) NewKeyPairFromConfig(config KeyPairConfig) (*Key
 		return nil, err
 	}
 
+	// If a serial number is provided, use it, otherwise use 42
+	serialNumber := config.SerialNumber
+	if serialNumber == nil {
+		serialNumber = big.NewInt(42)
+	}
+
 	// Create a Certificate
 	kp := &KeyPair{cert: &x509.Certificate{
 		Subject: pkix.Name{
@@ -167,7 +172,7 @@ func (ca *CertificateAuthority) NewKeyPairFromConfig(config KeyPairConfig) (*Key
 		},
 		DNSNames:     config.Domains,
 		IPAddresses:  ips,
-		SerialNumber: cmp.Or(config.SerialNumber, big.NewInt(42)),
+		SerialNumber: serialNumber,
 		NotBefore:    time.Now().Add(-1 * time.Hour),
 		NotAfter:     time.Now().Add(2 * time.Hour),
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},

--- a/testcerts.go
+++ b/testcerts.go
@@ -62,6 +62,7 @@ Simplify your testing, and don't hassle with certificates anymore.
 package testcerts
 
 import (
+	"cmp"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -162,10 +163,11 @@ func (ca *CertificateAuthority) NewKeyPairFromConfig(config KeyPairConfig) (*Key
 	kp := &KeyPair{cert: &x509.Certificate{
 		Subject: pkix.Name{
 			Organization: []string{"Never Use this Certificate in Production Inc."},
+			CommonName:   config.CommonName,
 		},
 		DNSNames:     config.Domains,
 		IPAddresses:  ips,
-		SerialNumber: big.NewInt(42),
+		SerialNumber: cmp.Or(config.SerialNumber, big.NewInt(42)),
 		NotBefore:    time.Now().Add(-1 * time.Hour),
 		NotAfter:     time.Now().Add(2 * time.Hour),
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},


### PR DESCRIPTION
Thanks for this library, we're finding it useful! 😄 

Just wanted to add the ability to set a serial number and common name when creating new key pairs.

Currently we have some tests that need distinct values for these which is making it a little bit harder to test what we need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for `SerialNumber` and `CommonName` in certificate generation, enhancing configurability.
- **Bug Fixes**
	- Improved handling of serial numbers and common names in the certificate generation process.
- **Tests**
	- Expanded test coverage for `KeyPairConfig` to validate new features and ensure correct functionality, including new test scenarios for serial numbers and common names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->