### PR TITLE
Adding methods for exporting

### DIFF
--- a/testcerts.go
+++ b/testcerts.go
@@ -194,6 +194,11 @@ func (ca *CertificateAuthority) NewKeyPairFromConfig(config KeyPairConfig) (*Key
 	return kp, nil
 }
 
+// Cert returns the CertificateAuthority Certificate.
+func (ca *CertificateAuthority) Cert() *x509.Certificate {
+	return ca.cert
+}
+
 // CertPool returns a Certificate Pool of the CertificateAuthority Certificate.
 func (ca *CertificateAuthority) CertPool() *x509.CertPool {
 	return ca.certPool
@@ -269,6 +274,11 @@ func (ca *CertificateAuthority) GenerateTLSConfig() *tls.Config {
 		RootCAs:   ca.CertPool(),
 		ClientCAs: ca.CertPool(),
 	}
+}
+
+// Cert returns the Certificate of the KeyPair.
+func (kp *KeyPair) Cert() *x509.Certificate {
+	return kp.cert
 }
 
 // PrivateKey returns the private key of the KeyPair.

--- a/testcerts_test.go
+++ b/testcerts_test.go
@@ -19,6 +19,18 @@ func TestCertsUsage(t *testing.T) {
 		t.Errorf("Unexpected key length from public/private key")
 	}
 
+	t.Run("Verify Cert",
+		func(t *testing.T) {
+			if cert := ca.Cert(); cert == nil {
+				t.Fatalf("Expected certificate, got nil")
+			} else if cert.SerialNumber.Cmp(big.NewInt(42)) != 0 {
+				t.Errorf("Unexpected Serial Number, expected 42 got %v", cert.SerialNumber)
+			} else if cert.Subject.Organization[0] != "Never Use this Certificate in Production Inc." {
+				t.Errorf("Unexpected Organization, expected 'Never Use this Certificate in Production Inc.' got %v", cert.Subject.Organization[0])
+			}
+		},
+	)
+
 	t.Run("Verify CertPool", func(t *testing.T) {
 		cp := x509.NewCertPool()
 		if cp.AppendCertsFromPEM(ca.PublicKey()) {
@@ -111,6 +123,12 @@ func TestCertsUsage(t *testing.T) {
 			if err != nil {
 				t.Errorf("NewKeyPair() returned error when generating with domains: %s", err)
 			}
+
+			t.Run("Verify Cert", func(t *testing.T) {
+				if cert := kp.Cert(); cert == nil {
+					t.Fatalf("Expected certificate, got nil")
+				}
+			})
 
 			t.Run("Validate Key Length", func(t *testing.T) {
 				if len(kp.PrivateKey()) == 0 || len(kp.PublicKey()) == 0 {


### PR DESCRIPTION
Adds a method to KeyPair and CertificateAuthority to export the certificate to an struct directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added methods to retrieve certificates directly from `CertificateAuthority` and `KeyPair`.
  
- **Bug Fixes**
	- Enhanced test coverage for certificate generation and validation within the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->